### PR TITLE
remove result and rresult dependencies

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,4 +1,4 @@
-version=0.18.0
+version=0.19.0
 module-item-spacing=compact
 break-struct=natural
 break-infix=fit-or-vertical

--- a/lib/dune
+++ b/lib/dune
@@ -2,7 +2,7 @@
  (name mimic)
  (public_name mimic)
  (modules hmap implicit mirage_protocol mimic)
- (libraries logs result rresult fmt mirage-flow lwt))
+ (libraries logs fmt mirage-flow lwt))
 
 (documentation
  (package mimic)

--- a/lib/hmap.ml
+++ b/lib/hmap.ml
@@ -10,8 +10,7 @@
 module Tid = struct type _ t = .. end
 
 module type Tid = sig
-  type t
-  type _ Tid.t += Tid : t Tid.t
+  type t type _ Tid.t += Tid : t Tid.t
 end
 
 type 'a tid = (module Tid with type t = 'a)

--- a/lib/mimic.ml
+++ b/lib/mimic.ml
@@ -106,7 +106,6 @@ module Implicit0 = Implicit.Make (struct
 end)
 
 type flow = Implicit0.t = private ..
-
 type error = [ `Msg of string | `Not_found | `Cycle ]
 type write_error = [ `Msg of string | `Closed ]
 
@@ -122,8 +121,8 @@ let pp_write_error ppf = function
 let read flow =
   let (Implicit0.Value (flow, (module Flow))) = Implicit0.prj flow in
   let open Lwt.Infix in
-  Flow.read flow >|=
-  Result.map_error (fun fe -> `Msg (Fmt.to_to_string Flow.pp_error fe))
+  Flow.read flow
+  >|= Result.map_error (fun fe -> `Msg (Fmt.to_to_string Flow.pp_error fe))
 
 let write flow cs =
   let (Implicit0.Value (flow, (module Flow))) = Implicit0.prj flow in
@@ -136,8 +135,9 @@ let write flow cs =
 let writev flow css =
   let (Implicit0.Value (flow, (module Flow))) = Implicit0.prj flow in
   let open Lwt.Infix in
-  Flow.writev flow css >|=
-  Result.map_error (fun fe -> `Msg (Fmt.to_to_string Flow.pp_write_error fe))
+  Flow.writev flow css
+  >|= Result.map_error (fun fe ->
+          `Msg (Fmt.to_to_string Flow.pp_write_error fe))
 
 let close flow =
   let (Implicit0.Value (flow, (module Flow))) = Implicit0.prj flow in
@@ -176,8 +176,7 @@ let register :
   value, { flow; protocol }
 
 module type REPR = sig
-  type t
-  type flow += (* XXX(dinosaure): private? *) T of t
+  type t type flow += (* XXX(dinosaure): private? *) T of t
 end
 
 let repr :
@@ -352,8 +351,7 @@ let flow_of_value :
   in
   go (Implicit1.bindings ())
 
-let inf = -1
-and sup = 1
+let inf = -1 and sup = 1
 
 let priority_compare (Edn (k0, _)) (Edn (k1, _)) =
   match (Hmap0.Key.info k0).root, (Hmap0.Key.info k1).root with

--- a/lib/mimic.mli
+++ b/lib/mimic.mli
@@ -39,8 +39,7 @@ val register :
   'edn value * ('edn, 'flow) protocol
 
 module type REPR = sig
-  type t
-  type flow += (* XXX(dinosaure): private? *) T of t
+  type t type flow += (* XXX(dinosaure): private? *) T of t
 end
 
 val repr : ('edn, 'flow) protocol -> (module REPR with type t = 'flow)

--- a/mimic.opam
+++ b/mimic.opam
@@ -13,8 +13,6 @@ depends: [
   "fmt" {>= "0.8.9"}
   "lwt" {>= "5.3.0"}
   "mirage-flow" {>= "2.0.1"}
-  "result" {>= "1.5"}
-  "rresult" {>= "0.6.0"}
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}
   "bigstringaf" {>= "0.7.0" & with-test}

--- a/test/dune
+++ b/test/dune
@@ -3,8 +3,6 @@
  (libraries
   mimic
   mirage-flow
-  result
-  rresult
   lwt
   lwt.unix
   logs

--- a/test/test.ml
+++ b/test/test.ml
@@ -75,12 +75,11 @@ let send = Alcotest.int
 
 let test_input_string =
   Alcotest_lwt.test_case "input string" `Quick @@ fun _sw () ->
-  let open Rresult in
   let open Lwt.Infix in
   let ctx = Mimic.add edn0 ("Hello World!", Bytes.empty) Mimic.empty in
   Mimic.resolve ctx >>= fun flow ->
-  Alcotest.(check bool) "resolve" (R.is_ok flow) true;
-  let flow = Flow.make (R.get_ok flow) in
+  Alcotest.(check bool) "resolve" (Result.is_ok flow) true;
+  let flow = Flow.make (Result.get_ok flow) in
   let buf0 = Cstruct.create 12 in
   let buf1 = Cstruct.create 12 in
   Flow.recv flow buf0 >>= fun res0 ->
@@ -96,13 +95,12 @@ let test_input_string =
 
 let test_output_string =
   Alcotest_lwt.test_case "output string" `Quick @@ fun _sw () ->
-  let open Rresult in
   let open Lwt.Infix in
   let buf = Bytes.create 12 in
   let ctx = Mimic.add edn0 ("", buf) Mimic.empty in
   Mimic.resolve ctx >>= fun flow ->
-  Alcotest.(check bool) "resolve" (R.is_ok flow) true;
-  let flow = Flow.make (R.get_ok flow) in
+  Alcotest.(check bool) "resolve" (Result.is_ok flow) true;
+  let flow = Flow.make (Result.get_ok flow) in
   Flow.send flow (Cstruct.of_string "Hell") >>= fun res0 ->
   Flow.send flow (Cstruct.of_string "o Wo") >>= fun res1 ->
   Flow.send flow (Cstruct.of_string "rld!") >>= fun res2 ->

--- a/test/unixiz.ml
+++ b/test/unixiz.ml
@@ -7,7 +7,6 @@ let blit1 src src_off dst dst_off len =
   Cstruct.blit src 0 dst dst_off len
 
 open Lwt.Infix
-open Rresult
 
 let ( >>? ) = Lwt_result.bind
 
@@ -29,7 +28,7 @@ module Make (Flow : Mirage_flow.S) = struct
 
   let recv flow payload =
     if Ke.Rke.is_empty flow.queue then (
-      Flow.read flow.flow >|= R.reword_error (fun err -> `Error err)
+      Flow.read flow.flow >|= Result.map_error (fun err -> `Error err)
       >>? function
       | `Eof -> Lwt.return_ok `End_of_flow
       | `Data res ->
@@ -47,7 +46,7 @@ module Make (Flow : Mirage_flow.S) = struct
 
   let send flow payload =
     Flow.write flow.flow payload >|= function
-    | Error `Closed -> R.error (`Write_error `Closed)
-    | Error err -> R.error (`Write_error err)
-    | Ok () -> R.ok (Cstruct.length payload)
+    | Error `Closed -> Error (`Write_error `Closed)
+    | Error err -> Error (`Write_error err)
+    | Ok () -> Ok (Cstruct.length payload)
 end


### PR DESCRIPTION
since OCaml 4.08 is the lower bound which provides a rich Stdlib Result module, there's no need to require these dependencies.