### PR TITLE
Introspect

### DIFF
--- a/lib/mimic.ml
+++ b/lib/mimic.ml
@@ -299,11 +299,11 @@ let sort bindings =
     | [], _ when progress -> go acc [] later false
     | [], later ->
         (* TODO(dinosaure): check, at least, one root in [acc]. *)
-        Log.warn (fun m ->
+        Log.debug (fun m ->
             m "Found a solution only for: @[<hov>%a@]."
               Fmt.(Dump.list Sort.pp)
               acc);
-        Log.warn (fun m ->
+        Log.debug (fun m ->
             m "Unsolvable values: @[<hov>%a@]." Fmt.(Dump.list pp_fnu) later);
         List.rev acc
     | (Fun (k, args, f) as x) :: xs, _ ->
@@ -367,6 +367,12 @@ let flow_of_value :
             | Error _err -> go r))
   in
   go (Implicit1.bindings ())
+
+type ('a, 'b) refl = Refl : ('a, 'a) refl
+
+let equal : type a b. a value -> b value -> (a, b) refl option =
+ fun a b ->
+  match Hmap0.Key.proof a b with Some Teq -> Some Refl | None -> None
 
 let rec connect : edn list -> (flow, [> error ]) result Lwt.t = function
   | [] -> Lwt.return_error `Not_found

--- a/lib/mimic.ml
+++ b/lib/mimic.ml
@@ -334,11 +334,11 @@ let unfold : ctx -> (edn list, [> `Cycle ]) result Lwt.t =
   let open Lwt.Infix in
   let rec go ctx acc : Sort.t list -> _ = function
     | [] ->
-      (* XXX(dinosaure): here, we use a stable sort, [List.rev]
-       * is needed to keep a certain topological order - see [sort].
-       * [stable_sort] keeps this order too. *)
-      let acc = List.stable_sort priority_compare (List.rev acc) in
-      Lwt.return_ok acc
+        (* XXX(dinosaure): here, we use a stable sort, [List.rev]
+         * is needed to keep a certain topological order - see [sort].
+         * [stable_sort] keeps this order too. *)
+        let acc = List.stable_sort priority_compare (List.rev acc) in
+        Lwt.return_ok acc
     | Sort.Val (k, v) :: r ->
         Log.debug (fun m -> m "Return a value %a." pp_value k);
         go ctx (Edn (k, v) :: acc) r

--- a/lib/mimic.mli
+++ b/lib/mimic.mli
@@ -45,6 +45,11 @@ end
 val repr : ('edn, 'flow) protocol -> (module REPR with type t = 'flow)
 val resolve : ctx -> (flow, [> error ]) result Lwt.t
 
+type edn = Edn : 'edn value * 'edn -> edn
+
+val unfold : ctx -> (edn list, [> `Cycle ]) result Lwt.t
+val connect : edn list -> (flow, [> error ]) result Lwt.t
+
 module Merge (A : sig
   val ctx : ctx
 end) (B : sig

--- a/lib/mimic.mli
+++ b/lib/mimic.mli
@@ -46,9 +46,11 @@ val repr : ('edn, 'flow) protocol -> (module REPR with type t = 'flow)
 val resolve : ctx -> (flow, [> error ]) result Lwt.t
 
 type edn = Edn : 'edn value * 'edn -> edn
+type (_, _) refl = Refl : ('a, 'a) refl
 
 val unfold : ctx -> (edn list, [> `Cycle ]) result Lwt.t
 val connect : edn list -> (flow, [> error ]) result Lwt.t
+val equal : 'a value -> 'b value -> ('a, 'b) refl option
 
 module Merge (A : sig
   val ctx : ctx


### PR DESCRIPTION
This PR adds 3 functions:
- `unfold` & `connect`, `resolve` applies these functions
- `equal` to find a specific value from what `unfold` produced from a given `ctx`

These functions are useful to introspect what `unfold` generated from a given `ctx` (what inner functions did when we do an usual `Mimic.resolve`). By this way, we can introspect the context-_prime_ where a protocol was initialized (with `connect`).