### PR TITLE
mimic-happy-eyeballs: other adjustments

### DIFF
--- a/mirage/mimic_happy_eyeballs.ml
+++ b/mirage/mimic_happy_eyeballs.ml
@@ -18,12 +18,12 @@ end
 
 module Make
     (Stack : Tcpip.Stack.V4V6)
-    (Happy_eyeballs : Happy_eyeballs_mirage.S
-                        with type flow = Stack.TCP.flow
-                         and type stack = Stack.t)
     (_ : Dns_client_mirage.S
            with type happy_eyeballs = Happy_eyeballs.t
-            and type Transport.stack = Happy_eyeballs.t * Stack.t) : sig
+            and type Transport.stack = Stack.t * Happy_eyeballs.t)
+    (Happy_eyeballs : Happy_eyeballs_mirage.S
+                        with type flow = Stack.TCP.flow
+                         and type stack = Stack.t) : sig
   include S with type t = Happy_eyeballs.t and type flow = Stack.TCP.flow
 
   val connect : Happy_eyeballs.t -> Mimic.ctx Lwt.t

--- a/mirage/mimic_happy_eyeballs.mli
+++ b/mirage/mimic_happy_eyeballs.mli
@@ -30,12 +30,12 @@ end
     user. *)
 module Make
     (Stack : Tcpip.Stack.V4V6)
-    (Happy_eyeballs : Happy_eyeballs_mirage.S
-                        with type flow = Stack.TCP.flow
-                         and type stack = Stack.t)
     (_ : Dns_client_mirage.S
            with type happy_eyeballs = Happy_eyeballs.t
-            and type Transport.stack = Happy_eyeballs.t * Stack.t) : sig
+            and type Transport.stack = Stack.t * Happy_eyeballs.t)
+    (Happy_eyeballs : Happy_eyeballs_mirage.S
+                        with type flow = Stack.TCP.flow
+                         and type stack = Stack.t) : sig
   include S with type t = Happy_eyeballs.t and type flow = Stack.TCP.flow
 
   val connect : t -> Mimic.ctx Lwt.t


### PR DESCRIPTION
Hey @dinosaure, I'm sorry I messed it up, but there are two issues that I'd like to solve with this PR (and would appreciate a re-release of mimic to get our mirage release out of the door):

* in 0.0.7, the functor arguments were first DNS the Happy_eyeballs, let's keep that
* in dns-client, the type stack is Stack.t * Happy_eyeballs -- not Happy_eyeballs * Stack.t

especially the second point requires a release, otherwise we won't be able to use mimic-happy-eyeballs at all. Thanks a lot.