### PR TITLE
We need to sort the functors in the other order

### DIFF
--- a/mirage/mimic_happy_eyeballs.ml
+++ b/mirage/mimic_happy_eyeballs.ml
@@ -18,12 +18,12 @@ end
 
 module Make
     (Stack : Tcpip.Stack.V4V6)
-    (_ : Dns_client_mirage.S
-           with type happy_eyeballs = Happy_eyeballs.t
-            and type Transport.stack = Stack.t * Happy_eyeballs.t)
     (Happy_eyeballs : Happy_eyeballs_mirage.S
                         with type flow = Stack.TCP.flow
-                         and type stack = Stack.t) : sig
+                         and type stack = Stack.t)
+    (_ : Dns_client_mirage.S
+           with type happy_eyeballs = Happy_eyeballs.t
+            and type Transport.stack = Stack.t * Happy_eyeballs.t) : sig
   include S with type t = Happy_eyeballs.t and type flow = Stack.TCP.flow
 
   val connect : Happy_eyeballs.t -> Mimic.ctx Lwt.t

--- a/mirage/mimic_happy_eyeballs.mli
+++ b/mirage/mimic_happy_eyeballs.mli
@@ -30,12 +30,12 @@ end
     user. *)
 module Make
     (Stack : Tcpip.Stack.V4V6)
-    (_ : Dns_client_mirage.S
-           with type happy_eyeballs = Happy_eyeballs.t
-            and type Transport.stack = Stack.t * Happy_eyeballs.t)
     (Happy_eyeballs : Happy_eyeballs_mirage.S
                         with type flow = Stack.TCP.flow
-                         and type stack = Stack.t) : sig
+                         and type stack = Stack.t)
+    (_ : Dns_client_mirage.S
+           with type happy_eyeballs = Happy_eyeballs.t
+            and type Transport.stack = Stack.t * Happy_eyeballs.t) : sig
   include S with type t = Happy_eyeballs.t and type flow = Stack.TCP.flow
 
   val connect : t -> Mimic.ctx Lwt.t


### PR DESCRIPTION
otherwise Happy_eyeballs.t will refer to a different implementation (the Happy_eyeballs.t from the happy-eyeballs opam package).

sorry for the noise.